### PR TITLE
Dependencies bump

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,12 +3,12 @@
   :url "https://github.com/sbelak/huri"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.9.0-alpha14"]
-                 [clj-time "0.13.0"]                                  
-                 [prismatic/plumbing "0.5.3"]                 
-                 [org.clojure/math.numeric-tower "0.0.4"]                 
-                 [org.clojure/data.priority-map "0.0.7"] 
-                 [net.cgrand/xforms "0.9.1"]  
-                 [cheshire "5.7.0"]
-                 [com.taoensso/timbre "4.8.0"]                 
+  :dependencies [[org.clojure/clojure "1.9.0-alpha17"]
+                 [clj-time "0.13.0"]
+                 [prismatic/plumbing "0.5.4"]
+                 [org.clojure/math.numeric-tower "0.0.4"]
+                 [org.clojure/data.priority-map "0.0.7"]
+                 [net.cgrand/xforms "0.9.3"]
+                 [cheshire "5.7.1"]
+                 [com.taoensso/timbre "4.10.0"]
                  [gorilla-renderable "2.0.0"]])

--- a/src/huri/core.clj
+++ b/src/huri/core.clj
@@ -5,8 +5,8 @@
             [clojure.data.priority-map :refer [priority-map-by]]            
             [clj-time.core :as t]
             [clojure.core.reducers :as r]
-            [clojure.spec :as s]
-            [clojure.spec.test :as s.test])
+            [clojure.spec.alpha :as s]
+            [clojure.spec.test.alpha :as s.test])
   (:import org.joda.time.DateTime))
 
 (defn papply


### PR DESCRIPTION
Otherwise, people using the latest alpha of clojure 1.9.0 can't use huri because it complains about clojure.spec