### PR TITLE
Add :arglists metadata in defplot

### DIFF
--- a/src/huri/plot.clj
+++ b/src/huri/plot.clj
@@ -321,6 +321,11 @@
                         (last params))
         body (last args)]
     `(defn ~name
+       {:arglists '([~'df]
+                    ~@(if y
+                        `[[~'options ~'df] [~@positional-params ~'df]]
+                        `[[~'arg ~'df]])
+                    [~@positional-params ~'options ~'df])}
        ([df#]
         (~name ~@(if y
                    [:x__auto :y__auto]


### PR DESCRIPTION
When using Huri in Gorilla REPL, completion for the plot functions shows
the gensym argument names, which are a bit difficult to parse,
especially for people who are now and exploring the API.

In this change I propose adding `:arglists` metadata to make this
better.

Doc before:

    huri.plot/scatter-plot
    ([df__20154__auto__] [options__20146__auto__ df__20147__auto__] [x y df__20148__auto__] [x y options__20155__auto__ df__20154__auto__])

And after:

    huri.plot/scatter-plot
    ([df] [options df] [x y df] [x y options df])

Thank you for your consideration!
