### PR TITLE
Bump plumbing dependency to get rid of a warning

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,9 +3,9 @@
   :url "https://github.com/sbelak/huri"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.9.0-alpha17"]
+  :dependencies [[org.clojure/clojure "1.9.0"]
                  [clj-time "0.13.0"]
-                 [prismatic/plumbing "0.5.4"]
+                 [prismatic/plumbing "0.5.5"]
                  [org.clojure/math.numeric-tower "0.0.4"]
                  [org.clojure/data.priority-map "0.0.7"]
                  [net.cgrand/xforms "0.9.3"]


### PR DESCRIPTION
This change bumps the prismatic/plumbing dependency from version 0.5.4 to 0.5.5. This gets rid of a warning that is logged when loading Huri:

```
WARNING: Inst already refers to: #'clojure.core/Inst in namespace: schema.core, being replaced by: #'schema.core/Inst
```

I am also upgrading Clojure from 1.9.0-alpha17 to 1.9.0. I think there is no harm in this version bump from an alpha to stable.
