### PR TITLE
Switch to data.xml for SVG transformation to fix label offset in plots

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -8,6 +8,7 @@
                  [prismatic/plumbing "0.5.4"]
                  [org.clojure/math.numeric-tower "0.0.4"]
                  [org.clojure/data.priority-map "0.0.7"]
+                 [org.clojure/data.xml "0.2.0-alpha5"]
                  [net.cgrand/xforms "0.9.3"]
                  [cheshire "5.7.1"]
                  [com.taoensso/timbre "4.10.0"]

--- a/src/huri/plot.clj
+++ b/src/huri/plot.clj
@@ -9,7 +9,7 @@
             [clojure.java.shell :as shell]            
             [clojure.walk :as walk]
             [gorilla-renderable.core :as render]
-            [clojure.xml :as xml]
+            [clojure.data.xml :as xml]
             [clj-time.core :as t])
   (:import org.joda.time.DateTime
            java.io.File
@@ -85,11 +85,11 @@
   This function is a workaround for that. It takes an SVG string and replaces 
   the ids with globally unique ids, returning a string."
   [svg]
-  (let [svg (xml/parse (java.io.ByteArrayInputStream. (.getBytes svg)))
+  (let [svg (xml/parse-str svg)
         smap (fresh-ids svg)
         mangle (fn [x]
                  (if (map? x)
-                   (into {}
+                   (into (with-meta {} (meta x))
                      (for [[k v] x]
                        [k (if (or (= :id k)
                                   (and (string? v)
@@ -98,8 +98,7 @@
                             (smap v)
                             v)]))
                    x))]
-    (with-out-str
-      (xml/emit (walk/prewalk mangle svg)))))
+    (xml/emit-str (walk/prewalk mangle svg))))
 
 (defn render
   ([plot-command]


### PR DESCRIPTION
This change switches to [data.xml](https://github.com/clojure/data.xml) for SVG transformation.

data.xml preserves the whitespace from the source document, so this should fix #17.

* I am depending on data.xml 0.2.0-alpha5 because only the 0.2.0 series includes XML namespace support, which is needed for SVG. As far as I know, the alpha is quite stable.
* I made one change to preserve metadata during the ID mangling. data.xml needs this metadata to generate the right XML namespace prefixes during emitting.

The worksheets I tried (and examined) with different plots etc. all look good, so this seems to completely resolve the issue!
