### PR TITLE
Fix exception when using :group-by in histogram

### DIFF
--- a/src/huri/plot.clj
+++ b/src/huri/plot.clj
@@ -496,7 +496,7 @@
                                   aesthetics))]
      (when show-mean?
        [:geom_vline [:aes {:xintercept [:mean x]}] {:linetype "dashed"
-                                                    :color (or group-by colour)
+                                                    :colour colour
                                                     :size 0.5}])
      [:geom_hline {:yintercept 0 :size 0.4 :colour "black"}]]))
 


### PR DESCRIPTION
`huri.plot/histogram` supports grouping with `:group-by`. When using grouping and `:show-mean?` is enabled at the same time, an exception is thrown and no plot is generated.

Since `:show-mean?` is true by default, this error is very easily triggered.

The change proposed here removes a (mistaken, as far as I can tell) reference to `group-by` in the drawing of the mean line.
