### PR TITLE
Support instant values satisfying the Inst protocol

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,7 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.9.0-alpha17"]
-                 [clj-time "0.13.0"]
+                 [clj-time "0.14.4"]
                  [prismatic/plumbing "0.5.4"]
                  [org.clojure/math.numeric-tower "0.0.4"]
                  [org.clojure/data.priority-map "0.0.7"]

--- a/src/huri/core.clj
+++ b/src/huri/core.clj
@@ -3,11 +3,9 @@
                                     map-from-vals map-from-keys]])
             [net.cgrand.xforms :as x]
             [clojure.data.priority-map :refer [priority-map-by]]            
-            [clj-time.core :as t]
             [clojure.core.reducers :as r]
             [clojure.spec.alpha :as s]
-            [clojure.spec.test.alpha :as s.test])
-  (:import org.joda.time.DateTime))
+            [clojure.spec.test.alpha :as s.test]))
 
 (defn papply
   "partial that applies its arguments."
@@ -557,9 +555,10 @@ the arguments passed in are not nill. Else returns nil."
   Optionally takes a keyfn to extract the values."
   ([xs]
    (let [[x & xs] xs]
-     (r/fold (r/monoid (if (instance? org.joda.time.DateTime x)
+     (r/fold (r/monoid (if (inst? x)
                          (fn [[acc-min acc-max] x]
-                           [(t/earliest acc-min x) (t/latest acc-max x)])
+                           [(min-key inst-ms acc-min x)
+                            (max-key inst-ms acc-max x)])
                          (fn [[acc-min acc-max] x]
                            [(min acc-min x) (max acc-max x)]))
                        (constantly [x x]))             


### PR DESCRIPTION
This change gently updates the date and time handling in Huri core and plots to support all `inst?` values, not just the type `org.joda.time.DateTime` used in clj-time. This has been made possible by a recent change in clj-time that extends `Inst` to `org.joda.time.DateTime`.

With this change, clj-time still has the same central position for handling time values in Huri. The `huri.time` namespace is untouched. It is just no longer a _requirement_ to use clj-time – `#inst` literals are now supported out of the box.
