### PR TITLE
Fix rollup-transpose spec

### DIFF
--- a/src/huri/core.clj
+++ b/src/huri/core.clj
@@ -296,9 +296,9 @@ the arguments passed in are not nill. Else returns nil."
 
 (s/fdef rollup-transpose
   :args (s/alt :curried (s/cat :indexfn ::keyfn
-                               :f (s/and ::summary-fn map?))
+                               :f (s/and map? ::summary-fn))
                :full (s/cat :indexfn ::keyfn
-                            :f (s/and ::summary-fn map?)
+                            :f (s/and map? ::summary-fn)
                             :df (s/nilable coll?)))
   :ret map?)
 


### PR DESCRIPTION
This change tweaks the spec for `huri.core/rollup-transpose` so that it no longer rejects well-formed arguments. Since `rollup-transpose` is automatically instrumented, this change is needed to allow `rollup-transpose` to be used at all.

This fixes #15.
