### PR TITLE
Add CDF plot

### DIFF
--- a/src/huri/plot.clj
+++ b/src/huri/plot.clj
@@ -500,6 +500,14 @@
                                                     :size 0.5}])
      [:geom_hline {:yintercept 0 :size 0.4 :colour "black"}]]))
 
+(defplot cdf-plot x {:pad? true}
+  [[:ggplot :g [:aes x (if group-by
+                         {:colour group-by}
+                         {})]]
+   [:stat_ecdf (merge {:pad pad?}
+                      (when-not group-by
+                        {:colour colour}))]])
+
 (defplot line-chart x y {:show-points? :auto
                          :fill? false
                          :alpha 0.5


### PR DESCRIPTION
The change proposed here is a new plot for empirical cumulative distribution functions, `cdf-plot`.

Several of the introductory stats texts I’ve read highlight how CDFs are superior to histograms for visualisation of the same data.

This is a minimal implementation that would be nice to have available in Huri.
